### PR TITLE
Update CustomTextures to patch all item icons & decoration sprites

### DIFF
--- a/CustomTextures/BepInExPlugin.cs
+++ b/CustomTextures/BepInExPlugin.cs
@@ -81,6 +81,58 @@ namespace CustomTextures
                 }
             }
         }
+        
+        [HarmonyPatch(typeof(ItemDatabase), "ConstructDatabase", new []{ typeof(IList<ItemData>)})]
+        static class ItemDatabase_ConstructDatabase_Patch
+        {
+            static void Postfix()
+            {
+                if (!modEnabled.Value)
+                    return;
+
+                try
+                {
+                    foreach (var item in ItemDatabase.items)
+                    {
+                        if (!item)
+                        {
+                            continue;
+                        }
+
+                        item.icon = TryGetReplacementSprite(item.icon);
+
+                        if (!item.useItem || !(item.useItem is Placeable placeable)) continue;
+
+
+                        if (placeable._previewSprite)
+                        {
+                            placeable._previewSprite = TryGetReplacementSprite(placeable._previewSprite);
+                        }
+
+                        if (placeable._secondaryPreviewSprite)
+                        {
+                            placeable._secondaryPreviewSprite = TryGetReplacementSprite(placeable._secondaryPreviewSprite);
+                        }
+
+                        if (!placeable._decoration) continue;
+
+                        foreach (var childGenerator in placeable._decoration.GetComponentsInChildren<MeshGenerator>())
+                        {
+                            Dbgl(childGenerator.name);
+                            if (childGenerator && childGenerator.sprite)
+                            {
+                                childGenerator.sprite = TryGetReplacementSprite(childGenerator.sprite);
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    context.Logger.LogError(e);
+                }
+            }
+        }
+        
         private static void LoadCustomTextures()
         {
             customTextureDict.Clear();

--- a/CustomTextures/BepInExPlugin.cs
+++ b/CustomTextures/BepInExPlugin.cs
@@ -118,7 +118,6 @@ namespace CustomTextures
 
                         foreach (var childGenerator in placeable._decoration.GetComponentsInChildren<MeshGenerator>())
                         {
-                            Dbgl(childGenerator.name);
                             if (childGenerator && childGenerator.sprite)
                             {
                                 childGenerator.sprite = TryGetReplacementSprite(childGenerator.sprite);


### PR DESCRIPTION
Since the last few Sun Haven patches, many decorations have stopped working with Custom Textures. This is because decorations are loaded into the scene after Unity's SceneManager.sceneLoaded is triggered. The most commonly mentioned issue was that the tier 1 house could no longer be changed.

At first I tried using the game's onFinishLoadingDecorations hook, but this resulted in custom texture popin because it's called after the player can already see the scene. Additionally it dramatically increases load times (because the farm for example has an extra 600 decorations which are then iterated over).

This approach does a one time patch of all the items in the game and their decorations, if applicable. It also allows item icons to be patched, a common complaint from users.